### PR TITLE
Change fail_ci_if_error to false in workflow

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -146,5 +146,5 @@ jobs:
             files: ./coverage.json
             flags: unittests
             name: codecov-umbrella
-            fail_ci_if_error: true
+            fail_ci_if_error: false
             verbose: true


### PR DESCRIPTION
Cambio de codecov

## Descripción de los cambios
---
(Añade aquí tu descripción)

### Finalidad de la PR
---
 <!-- Marca con una X el tipo de finalidad correspondiente '[x]' -->
- [ ] 🐛 (Bug)
- [ ] 🧑🏻‍💻 (Feature)
- [ ] 🌶️ (Hotfix)

### Tipo de cambio
---
 <!-- Marca con una X el tipo de cambio correspondiente '[x]' -->
- [ ] Corrección de errores 
- [ ] Nueva característica
- [ ] Mejora 
- [ ] Refactorización 
- [ ] Documentación 
- [ ] Otros


### Checklist
---

 <!-- Marca con una X los procesos cumplidos '[x]' -->

- [ ] He seguido las directrices del código.
- [ ] He realizado una revisión de código local.
- [ ] He ejecutado las pruebas y todas pasan.
- [ ] He añadido pruebas que prueban mis cambios.
- [ ] He actualizado la documentación si es necesario.

### Cómo probar los cambios
---
### Capturas de pantalla (si crees que es necesario)
---
### Notas adicionales
---
Nada que añadir

### URL de la tarea
---
(Añade aquí tu tarea)

## Summary by Sourcery

CI:
- Set fail_ci_if_error to false in the Codecov workflow step to prevent CI failures on errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline resilience by allowing builds to continue even if code coverage reporting encounters issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->